### PR TITLE
Singular Message is used with one friend online when AddFriendsToOnlineCount is false

### DIFF
--- a/src/Plugin/ModuleSystem/Modules/CurrentFriendsOnlineModule.cs
+++ b/src/Plugin/ModuleSystem/Modules/CurrentFriendsOnlineModule.cs
@@ -111,20 +111,18 @@ internal sealed class CurrentFriendsOnlineModule : BaseModule
                 }
                 else
                 {
-                    if (!this.Config.AddFriendNamesToOnlineCount)
+                    var chatMessage = new SeStringBuilder().AddText(string.Format(
+                        onlineFriendCount is 1 ? Strings.Modules_CurrentFriendsOnlineModule_SingularFriendOnline : Strings.Modules_CurrentFriendsOnlineModule_PluralFriendsOnline,
+                        onlineFriendCount));
+                    if (this.Config.AddFriendNamesToOnlineCount)
                     {
-                        DalamudInjections.ChatGui.Print(string.Format(Strings.Modules_CurrentFriendsOnlineModule_PluralFriendsOnline, onlineFriendCount));
-                        return;
-                    }
-                    var chatMessage = new SeStringBuilder().AddText(onlineFriendCount is 1
-                        ? string.Format(Strings.Modules_CurrentFriendsOnlineModule_SingularFriendOnline, onlineFriendCount)
-                        : string.Format(Strings.Modules_CurrentFriendsOnlineModule_PluralFriendsOnline, onlineFriendCount));
-                    foreach (var friend in characterData)
-                    {
-                        chatMessage.AddText($"\n - {friend.NameString}");
-                        if (DalamudInjections.ObjectTable.LocalPlayer?.HomeWorld.RowId != friend.HomeWorld)
+                        foreach (var friend in characterData)
                         {
-                            chatMessage.AddText(" ").AddIcon(BitmapFontIcon.CrossWorld).AddText(Services.WorldSheet.GetRow(friend.HomeWorld).Name.ExtractText());
+                            chatMessage.AddText($"\n - {friend.NameString}");
+                            if (DalamudInjections.ObjectTable.LocalPlayer?.HomeWorld.RowId != friend.HomeWorld)
+                            {
+                                chatMessage.AddText(" ").AddIcon(BitmapFontIcon.CrossWorld).AddText(Services.WorldSheet.GetRow(friend.HomeWorld).Name.ExtractText());
+                            }
                         }
                     }
                     DalamudInjections.ChatGui.Print(chatMessage.Build());


### PR DESCRIPTION
Hi, great plugin. I'm learning a bit about Dalamud and was looking at this repo as an example and figured what I'd try to fix what I think is a small bug.

Even though there is a singular format login message string when only one friend is online, I noticed it's not used when `AddFriendsToOnlineCount` is false, which it was for me by default. This happens because the message built in the conditional does not do the `onlineFriendCount` check that the main path takes. This PR fixes this with just one path that always concludes with a conditionally formatted `chatMessage`. 